### PR TITLE
improve room edit experience

### DIFF
--- a/bbbeasy-frontend/src/components/RoomDetails.tsx
+++ b/bbbeasy-frontend/src/components/RoomDetails.tsx
@@ -62,6 +62,7 @@ type formType = {
 
 type editFormItemType = {
     item: string;
+    label: JSX.Element;
     formItemNode: JSX.Element;
     isRequired?: boolean;
     messageItem?: string;
@@ -91,6 +92,7 @@ const RoomDetails = () => {
     const dataContext = React.useContext(DataContext);
 
     const [errorsEdit, setErrorsEdit] = React.useState({});
+    const [showSocialMedia, setShowSocialMedia] = useState(true);
     const [isEditing, setIsEditing] = React.useState<boolean>(false);
     const [labels, setLabels] = React.useState<LabelType[]>();
     const [presets, setPresets] = React.useState<PresetType[]>();
@@ -184,11 +186,13 @@ const RoomDetails = () => {
     const editFormItems: editFormItemType[] = [
         {
             item: 'name',
+            label: <Trans i18nKey="name.label" />,
             formItemNode: <Input />,
             isRequired: true,
         },
         {
             item: 'preset_id',
+            label: <Trans i18nKey="preset.label" />,
             formItemNode: (
                 <Select
                     className="select-field"
@@ -220,12 +224,14 @@ const RoomDetails = () => {
         },
         {
             item: 'labels',
+            label: <Trans i18nKey="labels" />,
             formItemNode: (
                 <Select mode="multiple" showArrow tagRender={tagRender} style={{ width: '100%' }} options={labels} notFoundContent={<NoData description={<Trans i18nKey="no_labels" />} className="empty-labels" />}/>
             ),
         },
         {
             item: 'short_link',
+            label: <Trans i18nKey="shortlink.label" />,
             formItemNode: <Input addonBefore={prefixShortLink} defaultValue={room?.short_link} />,
             isRequired: true,
             messageItem: 'shortlink',
@@ -233,6 +239,7 @@ const RoomDetails = () => {
     ];
     const toggleEdit = () => {
         setIsEditing(true);
+        setShowSocialMedia(false);
 
         const labels_data = [];
         room.labels.forEach((label) => {
@@ -249,9 +256,11 @@ const RoomDetails = () => {
     const cancelEdit = () => {
         setErrorsEdit({});
         setIsEditing(false);
+        setShowSocialMedia(true);
     };
     const handleSaveEdit = async () => {
         setErrorsEdit({});
+        setShowSocialMedia(true);
         try {
             const values = (await editForm.validateFields()) as formType;
 
@@ -277,7 +286,7 @@ const RoomDetails = () => {
         }
     };
     const customFormItem = (editFormItem: editFormItemType) => {
-        const { item, formItemNode, isRequired, messageItem } = editFormItem;
+        const { item, formItemNode, isRequired, messageItem, label } = editFormItem;
 
         return (
             <Form.Item
@@ -286,6 +295,7 @@ const RoomDetails = () => {
                     help: <Trans i18nKey={Object.keys(EN_US).filter((elem) => EN_US[elem] == errorsEdit[item])} />,
                     validateStatus: 'error',
                 })}
+                label={label}
                 rules={[
                     {
                         required: isRequired && true,
@@ -370,14 +380,14 @@ const RoomDetails = () => {
                                                     </>
                                                 ) : (
                                                     <Space size="middle" direction="vertical">
-                                                        <Form form={editForm}>
+                                                        <Form form={editForm} layout="vertical">
                                                             {editFormItems.map((editFormItem) => {
                                                                 return customFormItem(editFormItem);
                                                             })}
                                                         </Form>
                                                     </Space>
                                                 )}
-                                                <div className="medias">
+                                                {showSocialMedia && ( <div className="medias">
                                                     <Space size="middle">
                                                         <Tooltip
                                                             placement="bottom"
@@ -402,6 +412,7 @@ const RoomDetails = () => {
                                                         <MailOutlined />
                                                     </Tooltip>
                                                 </div>
+                                                )}
                                             </Space>
                                         </Col>
                                         {(canStart || isRunning) && (


### PR DESCRIPTION
## **Description**

Improve room edit experience, by adding  the labels (names) before the fields and hide the share icons.

## **Changes Made**

Adding labels and hide the share icons from the edit form.

## **Closes Issue(s)**

## **Related Issue(s)**
#525 
## **Types of changes**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Automated testing implementation or update
- [ ] Dependencies updated to a newer version
- [ ] Documentation update
- [ ] Experimental feature that requires further discussion

## **Screenshots and screen captures**
Before
![image](https://user-images.githubusercontent.com/130650065/235896924-72f9c62d-eb99-4cd1-a3ae-a0ce4a737cb3.png)

After
![image](https://user-images.githubusercontent.com/130650065/235897129-efd81846-2bc5-4a6c-ac12-73d1c2c056d1.png)
