### PR TITLE
Fix popup no changes made and cancel edit from room page.

### DIFF
--- a/bbbeasy-backend/app/src/Models/Room.php
+++ b/bbbeasy-backend/app/src/Models/Room.php
@@ -73,6 +73,11 @@ class Room extends BaseModel
         return $this->load(['short_link = ? and id != ?', $shortlink, $id]);
     }
 
+    public function presetExists($presetId, $name)
+    {
+        return $this->load(['preset_id = ? and name = ?', $presetId, $name]);
+    }
+
     /**
      * Get room record by link.
      *


### PR DESCRIPTION
## **Description**

Fix popup when no changes made.

## **Changes Made**

Added conditions to see if data has changed or not then show popup.

## **Closes Issue(s)**

## **Related Issue(s)**
https://github.com/riadvice/bbbeasy/issues/573

## **Types of changes**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Automated testing implementation or update
- [ ] Dependencies updated to a newer version
- [ ] Documentation update
- [ ] Experimental feature that requires further discussion

## **Screenshots and screen captures**

<img width="739" alt="image" src="https://user-images.githubusercontent.com/45165289/235932533-baeb775b-a699-4196-a840-c1ad3ede3eed.png">


<img width="436" alt="image" src="https://user-images.githubusercontent.com/45165289/235932948-5363fb40-b794-455a-b242-b752cc8e77cd.png">
