### PR TITLE
block the installer when install endpoints is inactif

### DIFF
--- a/bbbeasy-frontend/src/components/Install.tsx
+++ b/bbbeasy-frontend/src/components/Install.tsx
@@ -165,8 +165,8 @@ const Install = () => {
                 getPresetSettings();
             })
             .catch((error) => {
-                if (error.code === 'ERR_NETWORK') {
-                    setErrorNetwork(error.code);
+                if (error.response.status === 404) {
+                    setErrorNetwork(error.response.status);
                 }
 
                 if (error.response.data.locked) {

--- a/bbbeasy-frontend/src/components/Install.tsx
+++ b/bbbeasy-frontend/src/components/Install.tsx
@@ -165,7 +165,7 @@ const Install = () => {
                 getPresetSettings();
             })
             .catch((error) => {
-                if (error.response.status === 404) {
+                if (error.response.status !== 200) {
                     setErrorNetwork(error.response.status);
                 }
 

--- a/bbbeasy-frontend/src/locale/fr-FR.json
+++ b/bbbeasy-frontend/src/locale/fr-FR.json
@@ -306,8 +306,8 @@
     "edit_account_success": "Profil mis à jour avec succès",
     "install_locked_title": "Processus d'installation verrouillé",
     "install_locked_text": "Désolé, vous n'êtes pas autorisé à accéder à cette page, application déjà installée",
-    "install_error_title": "Processus d'installation est désactivé",
-    "install_error_text": "Processus d'installation doit etre activé dans la configuration backend.Veuillez recharger une fois mis à jour",
+    "install_error_title": "Processus d'installation est inactif",
+    "install_error_text": "Processus d'installation doit etre actif dans la configuration backend.Veuillez recharger une fois mis à jour",
 
     "recordings": "Enregistrements",
     "date_col": "Date",


### PR DESCRIPTION
## **Description**

Enter a brief description of the bug being fixed.
Currently when testing http://bbbeasy.test/api/install and the ; config.extension = -install the UI works without showing a notice.

## **Changes Made**
block the installer and show a notice when api/install returns 404 
Describe the changes made to fix the bug

## **Closes Issue(s)**

## **Related Issue(s)**
#517 
## **Types of changes**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Automated testing implementation or update
- [ ] Dependencies updated to a newer version
- [ ] Documentation update
- [ ] Experimental feature that requires further discussion

## **Screenshots and screen captures**
![image](https://user-images.githubusercontent.com/41712007/237049604-315b084c-16ca-4aef-b4df-85c1036dcadb.png)
