### PR TITLE
hide the gray preset groups

### DIFF
--- a/bbbeasy-frontend/src/components/Presets.tsx
+++ b/bbbeasy-frontend/src/components/Presets.tsx
@@ -361,6 +361,10 @@ const PresetsCol: React.FC<PresetColProps> = ({
                     const category = filteredElements.length != 0 ? filteredElements[0] : item.name;
 
                     return (
+                        <> 
+                        {item.enabled && (
+
+                        
                         <Tooltip
                             key={subIndex + '-' + item.name}
                             placement={
@@ -402,6 +406,8 @@ const PresetsCol: React.FC<PresetColProps> = ({
                                 icon={<DynamicIcon type={getIconName(item.name)} className={'PresetIcon'} />}
                             />
                         </Tooltip>
+                    )}
+                    </>
                     );
                 })}
 
@@ -517,6 +523,7 @@ const Presets = () => {
         const currentUser: UserType = AuthService.getCurrentUser();
         PresetsService.list_presets(currentUser.id)
             .then((response) => {
+                console.log(response.data)
                 setMyPresets(response.data);
             })
             .catch((error) => {


### PR DESCRIPTION
## **Description**

Enter a brief description of the bug being fixed.
Presets group with no editable option should not be visible  

## **Changes Made**
hide the gray preset group (disabled preset groups)
Describe the changes made to fix the bug

## **Closes Issue(s)**

## **Related Issue(s)**
#519 
## **Types of changes**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Automated testing implementation or update
- [ ] Dependencies updated to a newer version
- [ ] Documentation update
- [ ] Experimental feature that requires further discussion

## **Screenshots and screen captures**
![image](https://github.com/riadvice/bbbeasy/assets/41712007/763c4d7d-3c00-4f3c-b526-15ad26da43eb)
