### PR TITLE
Room cards size

### DIFF
--- a/bbbeasy-frontend/src/App-webapp.css
+++ b/bbbeasy-frontend/src/App-webapp.css
@@ -897,6 +897,9 @@ fieldset {
 .room-recordings-body .ant-card-body {
     padding: 20px !important;
 }
+.room-box{
+    display: grid !important;
+}
 .file-size {
     color: var(--bbbeasy-medimum-gray);
     font-size: 13px;

--- a/bbbeasy-frontend/src/components/Rooms.tsx
+++ b/bbbeasy-frontend/src/components/Rooms.tsx
@@ -94,7 +94,7 @@ const RoomsCol: React.FC<RoomsColProps> = ({ index, room, editable, deleteClickH
     );
 
     return (
-        <Col key={index} span={5} className="custom-col-5">
+        <Col key={index} span={5} className="custom-col-5 room-box">
             <Card
                 hoverable
                 onMouseOver={() => setIsShown(true)}


### PR DESCRIPTION
## **Description**

Room boxes are not equals when adding labels.

## **Changes Made**

Adding CSS style to make the room cards equals.

## **Closes Issue(s)**
#584 
## **Related Issue(s)**

## **Types of changes**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Automated testing implementation or update
- [ ] Dependencies updated to a newer version
- [ ] Documentation update
- [ ] Experimental feature that requires further discussion

## **Screenshots and screen captures**
<img width="382" alt="image" src="https://github.com/riadvice/bbbeasy/assets/130650065/d4084a16-f21c-4263-bcf9-af94524d53dc">
